### PR TITLE
Enable compatibility with @graphql-codegen/typed-document-node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "devDependencies": {
         "@apollo/client": "^3.4.16",
         "@grapes-agency/eslint-config": "^1.6.2",
+        "@graphql-typed-document-node/core": "^3.1.1",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-typescript": "^8.3.0",
         "@semantic-release/changelog": "^6.0.0",
@@ -782,12 +783,12 @@
       }
     },
     "node_modules/@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
       "dev": true,
       "peerDependencies": {
-        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -11724,9 +11725,9 @@
       }
     },
     "@graphql-typed-document-node/core": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.0.tgz",
-      "integrity": "sha512-wYn6r8zVZyQJ6rQaALBEln5B1pzxb9shV5Ef97kTvn6yVGrqyXVnDqnU24MXnFubR+rZjBY9NWuxX3FB2sTsjg==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.1.1.tgz",
+      "integrity": "sha512-NQ17ii0rK1b34VZonlmT2QMJFI70m0TRwbknO/ihlbatXyaktDhN/98vBiUU6kNBPljqGqyIrl2T4nY2RpFANg==",
       "dev": true,
       "requires": {}
     },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "devDependencies": {
     "@apollo/client": "^3.4.16",
     "@grapes-agency/eslint-config": "^1.6.2",
+    "@graphql-typed-document-node/core": "^3.1.1",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@semantic-release/changelog": "^6.0.0",

--- a/src/createLazyQuery.ts
+++ b/src/createLazyQuery.ts
@@ -1,6 +1,6 @@
 import { mergeOptions } from '@apollo/client/core'
 import type { QueryOptions, OperationVariables, ApolloError } from '@apollo/client/core'
-import type { DocumentNode } from 'graphql'
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
 import type { Accessor } from 'solid-js'
 import { onCleanup, untrack, createSignal, createResource } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
@@ -15,7 +15,7 @@ interface BaseOptions<TData, TVariables> extends Omit<QueryOptions<TVariables, T
 type CreateQueryOptions<TData, TVariables> = BaseOptions<TData, TVariables> | Accessor<BaseOptions<TData, TVariables>>
 
 export const createLazyQuery = <TData = {}, TVariables = OperationVariables>(
-  query: DocumentNode,
+  query: DocumentNode<TData, TVariables>,
   options: CreateQueryOptions<TData, TVariables> = {}
 ) => {
   const apolloClient = useApollo()

--- a/src/createMutation.ts
+++ b/src/createMutation.ts
@@ -1,6 +1,7 @@
 import { mergeOptions } from '@apollo/client/core'
 import type { DefaultContext, OperationVariables, MutationOptions, FetchResult } from '@apollo/client/core'
-import type { DocumentNode, GraphQLError } from 'graphql'
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
+import type { GraphQLError } from 'graphql'
 import type { Accessor } from 'solid-js'
 import { createResource, createSignal, untrack } from 'solid-js'
 
@@ -15,7 +16,7 @@ type CreateMutationOptions<TData, TVariables, TContext> =
   | Accessor<BaseOptions<TData, TVariables, TContext>>
 
 export const createMutation = <TData = any, TVariables = OperationVariables, TContext = DefaultContext>(
-  mutation: DocumentNode,
+  mutation: DocumentNode<TData, TVariables>,
   options: CreateMutationOptions<TData, TVariables, TContext> = {}
 ) => {
   const apolloClient = useApollo()

--- a/src/createQuery.ts
+++ b/src/createQuery.ts
@@ -1,5 +1,5 @@
 import type { WatchQueryOptions, OperationVariables } from '@apollo/client/core'
-import type { DocumentNode } from 'graphql'
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
 import type { Accessor } from 'solid-js'
 import { createResource, onCleanup } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
@@ -13,7 +13,7 @@ interface BaseOptions<TData, TVariables> extends Omit<WatchQueryOptions<TVariabl
 type CreateQueryOptions<TData, TVariables> = BaseOptions<TData, TVariables> | Accessor<BaseOptions<TData, TVariables>>
 
 export const createQuery = <TData = {}, TVariables = OperationVariables>(
-  query: DocumentNode,
+  query: DocumentNode<TData, TVariables>,
   options: CreateQueryOptions<TData, TVariables> = {}
 ) => {
   const apolloClient = useApollo()

--- a/src/createSubscription.ts
+++ b/src/createSubscription.ts
@@ -1,5 +1,5 @@
 import type { SubscriptionOptions, OperationVariables } from '@apollo/client/core'
-import type { DocumentNode } from 'graphql'
+import type { TypedDocumentNode as DocumentNode } from '@graphql-typed-document-node/core'
 import type { Accessor } from 'solid-js'
 import { createResource, onCleanup } from 'solid-js'
 import { createStore, reconcile } from 'solid-js/store'
@@ -11,7 +11,7 @@ type BaseOptions<TData, TVariables> = Omit<SubscriptionOptions<TVariables, TData
 type CreateSubscriptionOptions<TData, TVariables> = BaseOptions<TData, TVariables> | Accessor<BaseOptions<TData, TVariables>>
 
 export const createSubscription = <TData = {}, TVariables = OperationVariables>(
-  subscription: DocumentNode,
+  subscription: DocumentNode<TData, TVariables>,
   options: CreateSubscriptionOptions<TData, TVariables> = {}
 ) => {
   const apolloClient = useApollo()


### PR DESCRIPTION
Hey @Torsten85, thank you for this great library.

By using the `TypedDocumentNode` from the `@graphql-typed-document-node/core package` we can achieve typed queries using code generation as described here: https://www.graphql-code-generator.com/docs/guides/react#optimal-configuration-for-apollo-and-urql

```ts
import { createQuery } from '@merged/solid-apollo';
import { postsQueryDocument } from './graphql/generated';


const Posts = () => {
  const data = createQuery(postsQueryDocument);

  // `data` is fully typed!
  // ...
}
```