### PR TITLE
Upgrade solidjs package & fix ApolloProvider types and mergeOptions t…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,8 +26,8 @@
         "typescript": "^4.4.2"
       },
       "peerDependencies": {
-        "@apollo/client": "3.6.6",
-        "solid-js": "1.4.4"
+        "@apollo/client": "^3.6.0",
+        "solid-js": "^1.4.0"
       }
     },
     "node_modules/@apollo/client": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,52 +9,56 @@
       "version": "1.6.0",
       "license": "MIT",
       "devDependencies": {
-        "@apollo/client": "^3.4.16",
+        "@apollo/client": "3.6.6",
         "@grapes-agency/eslint-config": "^1.6.2",
         "@graphql-typed-document-node/core": "^3.1.1",
         "@rollup/plugin-babel": "^5.3.0",
         "@rollup/plugin-typescript": "^8.3.0",
         "@semantic-release/changelog": "^6.0.0",
         "@semantic-release/git": "^10.0.0",
-        "babel-preset-solid": "^1.1.7",
+        "babel-preset-solid": "1.4.4",
         "cz-conventional-changelog": "^3.3.0",
         "graphql": "^15.6.1",
         "rollup": "^2.58.0",
         "rollup-plugin-delete": "^2.0.0",
         "semantic-release": "^18.0.0",
-        "solid-js": "^1.1.7",
+        "solid-js": "1.4.4",
         "typescript": "^4.4.2"
       },
       "peerDependencies": {
-        "@apollo/client": "^3.4.0",
-        "solid-js": "^1.1.0"
+        "@apollo/client": "3.6.6",
+        "solid-js": "1.4.4"
       }
     },
     "node_modules/@apollo/client": {
-      "version": "3.4.16",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.16.tgz",
-      "integrity": "sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.6.tgz",
+      "integrity": "sha512-AzNLN043wy0bDTTR9wzKYSu+I1IT2Ox3+vWckxgIt88Jfw5jHBvumf3lXE1JlgvbFCTiKS/Sa66AadQXWMVBRQ==",
       "dev": true,
       "dependencies": {
-        "@graphql-typed-document-node/core": "^3.0.0",
+        "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.6.0",
         "@wry/equality": "^0.5.0",
         "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.3",
+        "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.0",
+        "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "~1.1.0"
+        "zen-observable-ts": "^1.2.5"
       },
       "peerDependencies": {
-        "graphql": "^14.0.0 || ^15.0.0",
-        "react": "^16.8.0 || ^17.0.0",
-        "subscriptions-transport-ws": "^0.9.0"
+        "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0",
+        "graphql-ws": "^5.5.5",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "subscriptions-transport-ws": "^0.9.0 || ^0.11.0"
       },
       "peerDependenciesMeta": {
+        "graphql-ws": {
+          "optional": true
+        },
         "react": {
           "optional": true
         },
@@ -277,12 +281,12 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -322,9 +326,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.17.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+      "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -373,9 +377,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true,
       "engines": {
         "node": ">=6.9.0"
@@ -505,12 +509,12 @@
       }
     },
     "node_modules/@babel/plugin-syntax-jsx": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "version": "7.17.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
+      "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.17.12"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -617,12 +621,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.18.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
+      "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -1564,12 +1568,6 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
-    "node_modules/@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
-      "dev": true
-    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -2052,24 +2050,24 @@
       "dev": true
     },
     "node_modules/babel-plugin-jsx-dom-expressions": {
-      "version": "0.29.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.29.19.tgz",
-      "integrity": "sha512-qg1N4S6E3S7I6rgqQE1xWH6p3eZpeDxrr+Al1Ptov0NjM69fKQQfeeAtyq1Q9DjdUOIhe9MGoCVA1X+TzXZzMA==",
+      "version": "0.33.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.33.8.tgz",
+      "integrity": "sha512-D9fNMObv6tepyA0g67aCxf+RS4jMiVAq/gGxEgYlyEE2mcokjV6OmqqowkHq77WIai1oZBALSuEVbJabxE5R5w==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "^7.10.4",
-        "@babel/types": "^7.11.5",
+        "@babel/helper-module-imports": "7.16.0",
+        "@babel/plugin-syntax-jsx": "^7.16.5",
+        "@babel/types": "^7.16.0",
         "html-entities": "2.3.2"
       }
     },
     "node_modules/babel-preset-solid": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.1.7.tgz",
-      "integrity": "sha512-OzteGVVg/3m3DC7Mo589m8KyyBZ6qO7JFhLHRusC0G/Xi6VukfKJZOpUkXGI4P7RDyLIANG3jqGVvzsjoLnihw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.4.4.tgz",
+      "integrity": "sha512-aas2u8tfZppQcrq7rSwOVHBLT1+v3p5D7mJ6a3EHc+9ld8suGxXSQs1yKYCJfm1b2PWfOajxb6daG04PMY991A==",
       "dev": true,
       "dependencies": {
-        "babel-plugin-jsx-dom-expressions": "^0.29.19"
+        "babel-plugin-jsx-dom-expressions": "^0.33.8"
       }
     },
     "node_modules/balanced-match": {
@@ -2201,15 +2199,21 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001352",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
+      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
       "dev": true,
-      "peer": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/browserslist"
-      }
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        }
+      ],
+      "peer": true
     },
     "node_modules/cardinal": {
       "version": "2.1.1",
@@ -4421,9 +4425,9 @@
       }
     },
     "node_modules/graphql-tag": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
-      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -4432,13 +4436,13 @@
         "node": ">=10"
       },
       "peerDependencies": {
-        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0"
+        "graphql": "^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-tag/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/handlebars": {
@@ -10236,9 +10240,9 @@
       }
     },
     "node_modules/solid-js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.1.7.tgz",
-      "integrity": "sha512-+zZOdR++hFJ/dEmAaHjyI5/tPqRdItOVKsnLuBOKajCqG0n/Bs3uc8xWf8CiYTI7OIwSt5A6ASM8KDoKehfs6w==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.4.tgz",
+      "integrity": "sha512-nf/cbRzMuhb5UjbRDNfSJPqHKzUxNb9YgCQwijPUbdA3koQ/hWrz/lj0ter3lvThgxinvGPtXofDGy9bsKrXqA==",
       "dev": true
     },
     "node_modules/source-map": {
@@ -10752,9 +10756,9 @@
       }
     },
     "node_modules/ts-invariant": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.1.tgz",
-      "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dev": true,
       "dependencies": {
         "tslib": "^2.1.0"
@@ -10764,9 +10768,9 @@
       }
     },
     "node_modules/ts-invariant/node_modules/tslib": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-      "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
       "dev": true
     },
     "node_modules/ts-node": {
@@ -11120,35 +11124,34 @@
       "dev": true
     },
     "node_modules/zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dev": true,
       "dependencies": {
-        "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
       }
     }
   },
   "dependencies": {
     "@apollo/client": {
-      "version": "3.4.16",
-      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.4.16.tgz",
-      "integrity": "sha512-iF4zEYwvebkri0BZQyv8zfavPfVEafsK0wkOofa6eC2yZu50J18uTutKtC174rjHZ2eyxZ8tV7NvAPKRT+OtZw==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.6.6.tgz",
+      "integrity": "sha512-AzNLN043wy0bDTTR9wzKYSu+I1IT2Ox3+vWckxgIt88Jfw5jHBvumf3lXE1JlgvbFCTiKS/Sa66AadQXWMVBRQ==",
       "dev": true,
       "requires": {
-        "@graphql-typed-document-node/core": "^3.0.0",
+        "@graphql-typed-document-node/core": "^3.1.1",
         "@wry/context": "^0.6.0",
         "@wry/equality": "^0.5.0",
         "@wry/trie": "^0.3.0",
-        "graphql-tag": "^2.12.3",
+        "graphql-tag": "^2.12.6",
         "hoist-non-react-statics": "^3.3.2",
         "optimism": "^0.16.1",
         "prop-types": "^15.7.2",
         "symbol-observable": "^4.0.0",
-        "ts-invariant": "^0.9.0",
+        "ts-invariant": "^0.10.3",
         "tslib": "^2.3.0",
-        "zen-observable-ts": "~1.1.0"
+        "zen-observable-ts": "^1.2.5"
       },
       "dependencies": {
         "tslib": {
@@ -11321,12 +11324,12 @@
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-module-transforms": {
@@ -11357,9 +11360,9 @@
       }
     },
     "@babel/helper-plugin-utils": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==",
+      "version": "7.17.12",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.17.12.tgz",
+      "integrity": "sha512-JDkf04mqtN3y4iAbO1hv9U2ARpPyPL1zqyWs/2WG1pgSq9llHFjStX5jdxb84himgJm+8Ng+x0oiWF/nw/XQKA==",
       "dev": true
     },
     "@babel/helper-replace-supers": {
@@ -11396,9 +11399,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "version": "7.16.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+      "integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -11497,12 +11500,12 @@
       "peer": true
     },
     "@babel/plugin-syntax-jsx": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.14.5.tgz",
-      "integrity": "sha512-ohuFIsOMXJnbOMRfX7/w7LocdR6R7whhuRD4ax8IipLcLPlZGJKkBxgHp++U4N/vKyU16/YDQr2f5seajD3jIw==",
+      "version": "7.17.12",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.17.12.tgz",
+      "integrity": "sha512-spyY3E3AURfxh/RHtjx5j6hs8am5NbUBGfcZ2vB3uShSpZdQyXSf5rR5Mk76vbtlAZOelyVQ71Fg0x9SG4fsog==",
       "dev": true,
       "requires": {
-        "@babel/helper-plugin-utils": "^7.14.5"
+        "@babel/helper-plugin-utils": "^7.17.12"
       }
     },
     "@babel/runtime": {
@@ -11586,12 +11589,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
+      "version": "7.18.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.4.tgz",
+      "integrity": "sha512-ThN1mBcMq5pG/Vm2IcBmPPfyPXbd8S02rS+OBIDENdufvqC7Z/jHPCv9IcP01277aKtDI8g/2XysBN4hA8niiw==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.14.9",
+        "@babel/helper-validator-identifier": "^7.16.7",
         "to-fast-properties": "^2.0.0"
       }
     },
@@ -12349,12 +12352,6 @@
       "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g==",
       "dev": true
     },
-    "@types/zen-observable": {
-      "version": "0.8.3",
-      "resolved": "https://registry.npmjs.org/@types/zen-observable/-/zen-observable-0.8.3.tgz",
-      "integrity": "sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==",
-      "dev": true
-    },
     "@typescript-eslint/eslint-plugin": {
       "version": "4.33.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
@@ -12690,24 +12687,24 @@
       "dev": true
     },
     "babel-plugin-jsx-dom-expressions": {
-      "version": "0.29.19",
-      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.29.19.tgz",
-      "integrity": "sha512-qg1N4S6E3S7I6rgqQE1xWH6p3eZpeDxrr+Al1Ptov0NjM69fKQQfeeAtyq1Q9DjdUOIhe9MGoCVA1X+TzXZzMA==",
+      "version": "0.33.8",
+      "resolved": "https://registry.npmjs.org/babel-plugin-jsx-dom-expressions/-/babel-plugin-jsx-dom-expressions-0.33.8.tgz",
+      "integrity": "sha512-D9fNMObv6tepyA0g67aCxf+RS4jMiVAq/gGxEgYlyEE2mcokjV6OmqqowkHq77WIai1oZBALSuEVbJabxE5R5w==",
       "dev": true,
       "requires": {
-        "@babel/helper-module-imports": "^7.10.4",
-        "@babel/plugin-syntax-jsx": "^7.10.4",
-        "@babel/types": "^7.11.5",
+        "@babel/helper-module-imports": "7.16.0",
+        "@babel/plugin-syntax-jsx": "^7.16.5",
+        "@babel/types": "^7.16.0",
         "html-entities": "2.3.2"
       }
     },
     "babel-preset-solid": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.1.7.tgz",
-      "integrity": "sha512-OzteGVVg/3m3DC7Mo589m8KyyBZ6qO7JFhLHRusC0G/Xi6VukfKJZOpUkXGI4P7RDyLIANG3jqGVvzsjoLnihw==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/babel-preset-solid/-/babel-preset-solid-1.4.4.tgz",
+      "integrity": "sha512-aas2u8tfZppQcrq7rSwOVHBLT1+v3p5D7mJ6a3EHc+9ld8suGxXSQs1yKYCJfm1b2PWfOajxb6daG04PMY991A==",
       "dev": true,
       "requires": {
-        "babel-plugin-jsx-dom-expressions": "^0.29.19"
+        "babel-plugin-jsx-dom-expressions": "^0.33.8"
       }
     },
     "balanced-match": {
@@ -12808,9 +12805,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001271",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001271.tgz",
-      "integrity": "sha512-BBruZFWmt3HFdVPS8kceTBIguKxu4f99n5JNp06OlPD/luoAMIaIK5ieV5YjnBLH3Nysai9sxj9rpJj4ZisXOA==",
+      "version": "1.0.30001352",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001352.tgz",
+      "integrity": "sha512-GUgH8w6YergqPQDGWhJGt8GDRnY0L/iJVQcU3eJ46GYf52R8tk0Wxp0PymuFVZboJYXGiCqwozAYZNRjVj6IcA==",
       "dev": true,
       "peer": true
     },
@@ -14514,18 +14511,18 @@
       "dev": true
     },
     "graphql-tag": {
-      "version": "2.12.5",
-      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.5.tgz",
-      "integrity": "sha512-5xNhP4063d16Pz3HBtKprutsPrmHZi5IdUGOWRxA2B6VF7BIRGOHZ5WQvDmJXZuPcBg7rYwaFxvQYjqkSdR3TQ==",
+      "version": "2.12.6",
+      "resolved": "https://registry.npmjs.org/graphql-tag/-/graphql-tag-2.12.6.tgz",
+      "integrity": "sha512-FdSNcu2QQcWnM2VNvSCCDCVS5PpPqpzgFT8+GXzqJuoDd0CBncxCY278u4mhRO7tMgo2JjgJA5aZ+nWSQ/Z+xg==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -18766,9 +18763,9 @@
       }
     },
     "solid-js": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.1.7.tgz",
-      "integrity": "sha512-+zZOdR++hFJ/dEmAaHjyI5/tPqRdItOVKsnLuBOKajCqG0n/Bs3uc8xWf8CiYTI7OIwSt5A6ASM8KDoKehfs6w==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.4.4.tgz",
+      "integrity": "sha512-nf/cbRzMuhb5UjbRDNfSJPqHKzUxNb9YgCQwijPUbdA3koQ/hWrz/lj0ter3lvThgxinvGPtXofDGy9bsKrXqA==",
       "dev": true
     },
     "source-map": {
@@ -19181,18 +19178,18 @@
       "dev": true
     },
     "ts-invariant": {
-      "version": "0.9.1",
-      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.9.1.tgz",
-      "integrity": "sha512-hSeYibh29ULlHkuEfukcoiyTct+s2RzczMLTv4x3NWC/YrBy7x7ps5eYq/b4Y3Sb9/uAlf54+/5CAEMVxPhuQw==",
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/ts-invariant/-/ts-invariant-0.10.3.tgz",
+      "integrity": "sha512-uivwYcQaxAucv1CzRp2n/QdYPo4ILf9VXgH19zEIjFx2EJufV16P0JtJVpYHy89DItG6Kwj2oIUjrcK5au+4tQ==",
       "dev": true,
       "requires": {
         "tslib": "^2.1.0"
       },
       "dependencies": {
         "tslib": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
-          "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
+          "version": "2.4.0",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
+          "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
           "dev": true
         }
       }
@@ -19463,12 +19460,11 @@
       "dev": true
     },
     "zen-observable-ts": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.1.0.tgz",
-      "integrity": "sha512-1h4zlLSqI2cRLPJUHJFL8bCWHhkpuXkF+dbGkRaWjgDIG26DmzyshUMrdV/rL3UnR+mhaX4fRq8LPouq0MYYIA==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-1.2.5.tgz",
+      "integrity": "sha512-QZWQekv6iB72Naeake9hS1KxHlotfRpe+WGNbNx5/ta+R3DNjVO2bswf63gXlWDcs+EMd7XY8HfVQyP1X6T4Zg==",
       "dev": true,
       "requires": {
-        "@types/zen-observable": "0.8.3",
         "zen-observable": "0.8.15"
       }
     }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
   "author": "Torsten Blindert",
   "license": "MIT",
   "peerDependencies": {
-    "@apollo/client": "3.6.6",
-    "solid-js": "1.4.4"
+    "@apollo/client": "^3.6.0",
+    "solid-js": "^1.4.0"
   },
   "devDependencies": {
     "@apollo/client": "3.6.6",

--- a/package.json
+++ b/package.json
@@ -32,24 +32,24 @@
   "author": "Torsten Blindert",
   "license": "MIT",
   "peerDependencies": {
-    "@apollo/client": "^3.4.0",
-    "solid-js": "^1.1.0"
+    "@apollo/client": "3.6.6",
+    "solid-js": "1.4.4"
   },
   "devDependencies": {
-    "@apollo/client": "^3.4.16",
+    "@apollo/client": "3.6.6",
     "@grapes-agency/eslint-config": "^1.6.2",
     "@graphql-typed-document-node/core": "^3.1.1",
     "@rollup/plugin-babel": "^5.3.0",
     "@rollup/plugin-typescript": "^8.3.0",
     "@semantic-release/changelog": "^6.0.0",
     "@semantic-release/git": "^10.0.0",
-    "babel-preset-solid": "^1.1.7",
+    "babel-preset-solid": "1.4.4",
     "cz-conventional-changelog": "^3.3.0",
     "graphql": "^15.6.1",
     "rollup": "^2.58.0",
     "rollup-plugin-delete": "^2.0.0",
     "semantic-release": "^18.0.0",
-    "solid-js": "^1.1.7",
+    "solid-js": "1.4.4",
     "typescript": "^4.4.2"
   },
   "prettier": "@grapes-agency/eslint-config/prettier",

--- a/src/ApolloProvider.tsx
+++ b/src/ApolloProvider.tsx
@@ -1,5 +1,5 @@
 import type { ApolloClient } from '@apollo/client/core'
-import type { Component } from 'solid-js'
+import type { ParentComponent } from 'solid-js'
 import { createContext, useContext } from 'solid-js'
 
 const ApolloContext = createContext<ApolloClient<any>>()
@@ -8,7 +8,7 @@ export interface ApolloProviderProps {
   client: ApolloClient<any>
 }
 
-export const ApolloProvider: Component<ApolloProviderProps> = props => (
+export const ApolloProvider: ParentComponent<ApolloProviderProps> = props => (
   <ApolloContext.Provider value={props.client}>{props.children}</ApolloContext.Provider>
 )
 

--- a/src/createLazyQuery.ts
+++ b/src/createLazyQuery.ts
@@ -62,7 +62,7 @@ export const createLazyQuery = <TData = {}, TVariables = OperationVariables>(
 
   return [
     async (opts: BaseOptions<TData, TVariables> = {}) => {
-      const mergedOptions = mergeOptions(opts, { query, ...(typeof options === 'function' ? untrack(options) : options) })
+      const mergedOptions = mergeOptions<QueryOptions<TVariables, TData>>(opts, { query, ...(typeof options === 'function' ? untrack(options) : options) })
       setExecutionOptions(mergedOptions)
       return new Promise<TData>((resolve, reject) => {
         resolveResultPromise = resolve

--- a/src/createMutation.ts
+++ b/src/createMutation.ts
@@ -54,7 +54,7 @@ export const createMutation = <TData = any, TVariables = OperationVariables, TCo
 
   return [
     async (opts: BaseOptions<TData, TVariables, TContext> = {}) => {
-      const mergedOptions = mergeOptions(opts, { mutation, ...(typeof options === 'function' ? untrack(options) : options) })
+      const mergedOptions = mergeOptions<MutationOptions<TData, TVariables, TContext>>(opts, { mutation, ...(typeof options === 'function' ? untrack(options) : options) })
 
       setExecutionOptions(mergedOptions)
       return new Promise<TData>((resolve, reject) => {


### PR DESCRIPTION
Hi @Torsten85,

I upgraded solidjs and apollo client packages, to resolve the type problem for ApolloProvider,
right now Component type doesn't have children inside so We have to use ParentComponent type instead.

I also pass a type for mergeOptions in src/createLazyQuery.ts and src/createMutation.ts

You can check it!
Cheers :)

Signed-off-by: Benjamin Rast <benjaminrast93@gmail.com>