### PR TITLE
chore(package.json): add exports.types to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
-      "default": "./dist/es/index.js"
+      "default": "./dist/es/index.js",
+      "types": "./dist/types/index.d.ts"
     }
   },
   "keywords": [


### PR DESCRIPTION
add explicit `exports.types` declaration for typing support in package.json

Fix error ts7016 appearing when importing the library in project.

Error reads:
```
Could not find a declaration file for module '@merged/solid-apollo'. './node_modules/@merged/solid-apollo/dist/es/index.js' implicitly has an 'any' type.
There are types at './node_modules/@merged/solid-apollo/dist/types/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@merged/solid-apollo' library may need to update its package.json or typings.ts(7016)
```